### PR TITLE
Numpy / Scipy computation of knn entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The copula entropy based statistic for multivariate normality test is implemente
 * k: kth nearest neighbour, parameter for kNN entropy estimation. default = 3;
 * dtype: distance type, can be 'euclidean' or 'chebychev' (for Maximum Distance);
 * lag: time lag. default = 1;
-* mode: running mode, 1(default) for speed/small data, 2 for space/large data.
 
 #### Installation
 The package can be installed from PyPI directly:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The copula entropy based statistic for multivariate normality test is implemente
 #### Parameters
 * x: N * d data, N samples, d dimensions;
 * k: kth nearest neighbour, parameter for kNN entropy estimation. default = 3;
-* dtype: distance type, 1 for 'Euclidean', 2/others (default) for 'Maximum distance';
+* dtype: distance type, can be 'euclidean' or 'chebychev' (for Maximum Distance);
 * lag: time lag. default = 1;
 * mode: running mode, 1(default) for speed/small data, 2 for space/large data.
 

--- a/copent/copent.py
+++ b/copent/copent.py
@@ -24,32 +24,10 @@ from scipy.special import digamma
 from scipy.stats import rankdata as rank 
 from scipy.spatial.distance import cdist
 from math import gamma, log, pi
-from numpy import array, ndarray, abs, max, sum, sqrt, square, vstack, zeros, cov
+from numpy import array, abs, max, vstack, zeros, cov
 from numpy.random import normal as rnorm
 from numpy.linalg import det
 import numpy as np
-
-##### calculating distance matrix
-def dist(x, dtype = 2):
-	(N,d) = x.shape
-	xd = ndarray(shape = (N,N), dtype = float)
-	
-	for i in range(0,N):
-		for j in range(i,N):
-			if dtype == 1:
-				xd[i,j] = sqrt(sum(square(x[i,:]-x[j,:])))
-				xd[j,i] = xd[i,j]
-			else: ## dtype = 2
-				xd[i,j] = max(abs(x[i,:]-x[j,:]))
-				xd[j,i] = xd[i,j]
-	
-	return xd
-##### calculating the distance between two samples
-def dist_ij(xi,xj, dtype = 2):
-	if dtype == 1:
-		return sqrt(sum(square(xi-xj)))
-	else: ## dtype = 2
-		return max(abs(xi-xj))
 
 ##### constructing empirical copula density [1]
 def construct_empirical_copula(x):

--- a/copent/copent.py
+++ b/copent/copent.py
@@ -6,8 +6,7 @@
 ###  Parameters
 ###	x    	: N * d data, N samples, d dimensions
 ###	k    	: kth nearest neighbour, parameter for kNN entropy estimation. default = 3
-###	dtype	: distance type [1: 'Euclidean', 2/others (default): 'Maximum distance']
-###	mode	: running mode [1(default): for speed/small data, 2: for space/large data]
+###	dtype	: distance type ['euclidean', 'chebychev' (i.e Maximum distance)]
 ###	lag	: time lag. default = 1
 ###
 ###  References
@@ -23,10 +22,12 @@
 
 from scipy.special import digamma
 from scipy.stats import rankdata as rank 
+from scipy.spatial.distance import cdist
 from math import gamma, log, pi
 from numpy import array, ndarray, abs, max, sum, sqrt, square, vstack, zeros, cov
 from numpy.random import normal as rnorm
 from numpy.linalg import det
+import numpy as np
 
 ##### calculating distance matrix
 def dist(x, dtype = 2):
@@ -60,34 +61,25 @@ def construct_empirical_copula(x):
 	return xc
 
 ##### Estimating entropy with kNN method [2]
-def entknn(x, k = 3, dtype = 2, mode = 1):
+def entknn(x, k = 3, dtype = 'euclidean'):
 	(N,d) = x.shape
 	
 	g1 = digamma(N) - digamma(k)
 	
-	if dtype == 1:	# euciledean distance
-		cd = pi**(d/2) / 2**d / gamma(1+d/2)	
-	else:	# maximum distance
+	if dtype == 'euclidean':
+		cd = pi**(d/2) / 2**d / gamma(1+d/2)
+	else:	# (chebychev) maximum distance
 		cd = 1;
-	
+
 	logd = 0
-	if mode == 1: # for speed / small data
-		distx = dist(x, dtype)		
-		for i in range(0,N):
-			distx[i,:].sort()
-			logd = logd + log( 2 * distx[i,k] ) * d / N
-	else: # 2, for space / large data
-		for i in range(0,N):
-			disti = []
-			for j in range(0,N):
-				disti.append( dist_ij(x[i,:],x[j,:],dtype) )
-			disti.sort()
-			logd = logd + log( 2 * disti[k] ) * d / N
+	dists = cdist(x, x, dtype)
+	dists.sort()
+	logd = np.cumsum(np.log(dists[:, k] * 2) * d / N)[-1]
 
 	return (g1 + log(cd) + logd)
 
 ##### 2-step Nonparametric estimation of copula entropy [1]
-def copent(x, k = 3, dtype = 2, mode = 1, log0 = False):
+def copent(x, k = 3, dtype = 'chebychev', log0 = False):
 	xarray = array(x)
 
 	if log0:
@@ -102,21 +94,21 @@ def copent(x, k = 3, dtype = 2, mode = 1, log0 = False):
 	xc = construct_empirical_copula(xarray)
 
 	try:
-		return -entknn(xc, k, dtype, mode)
+		return -entknn(xc, k, dtype)
 	except ValueError: # log0 error
-		return copent(x, k, dtype, mode, log0 = True)
+		return copent(x, k, dtype, log0 = True)
 
 
 ##### conditional independence test [3]
 ##### to test independence of (x,y) conditioned on z
-def ci(x, y, z, k = 3, dtype = 2, mode = 1):
+def ci(x, y, z, k = 3, dtype = 2):
 	xyz = vstack((x,y,z)).T
 	yz = vstack((y,z)).T
 	xz = vstack((x,z)).T
-	return copent(xyz,k,dtype,mode) - copent(yz,k,dtype,mode) - copent(xz,k,dtype,mode)
+	return copent(xyz,k,dtype) - copent(yz,k,dtype) - copent(xz,k,dtype)
 
 ##### estimating transfer entropy from y to x with lag [3]
-def transent(x, y, lag = 1, k = 3, dtype = 2, mode = 1):
+def transent(x, y, lag = 1, k = 3, dtype = 'euclidean'):
 	xlen = len(x)
 	ylen = len(y)
 	if (xlen > ylen):
@@ -128,9 +120,8 @@ def transent(x, y, lag = 1, k = 3, dtype = 2, mode = 1):
 	x1 = x[0:(l-lag)]
 	x2 = x[lag:l]
 	y = y[0:(l-lag)]
-	return ci(x2,y,x1,k,dtype,mode)
+	return ci(x2,y,x1,k,dtype)
 
 ##### multivariate normality test [4]
-def mvnt(x, k = 3, dtype = 2, mode = 1):
-	return -0.5 * log(det(cov(x.T))) - copent(x,k,dtype,mode)
-
+def mvnt(x, k = 3, dtype = 'euclidean'):
+	return -0.5 * log(det(cov(x.T))) - copent(x,k,dtype)

--- a/tests/test_knn_entropy.py
+++ b/tests/test_knn_entropy.py
@@ -1,0 +1,15 @@
+import pytest
+import numpy as np
+import numpy.testing
+
+import copent
+
+@pytest.mark.parametrize("dtype, entropy", [
+    ('euclidean', 5.68),
+    ('chebychev', 5.73),
+])
+def test_knn_entropy(dtype, entropy):
+    arr = np.array([[ 1,  2], [ 2,  5], [10, 10]])
+
+    res = copent.entknn(arr, dtype=dtype, k=1)
+    assert res == pytest.approx(entropy, abs=0.01)


### PR DESCRIPTION
This PR tries to simplify the codebase a bit, by
* importing distance function from SciPy, for faster computation of distances, deprecating the `mode`argument that was here to control space consumption 
* set the `dtype`arg as a string, either being `euclidean` or `chebychev` (for the "maximum distance" mode). This is to make the implementation compliant with terminology used in the scipy/numpy world

Note : running the python scripts in `tests`, one should observe exactly the same results as before, as the integers arguments previously setting `dtype` have been replaced by their corresponding string, in every function